### PR TITLE
Add argument for DeltaTable storage options

### DIFF
--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -36,7 +36,11 @@ class DeltaTableWrapper(object):
         self.columns = columns
         self.datetime = datetime
         self.storage_options = storage_options
-        self.dt = DeltaTable(table_uri=self.path, version=self.version, storage_options=delta_storage_options)
+        self.dt = DeltaTable(
+            table_uri=self.path,
+            version=self.version,
+            storage_options=delta_storage_options,
+        )
         self.fs, self.fs_token, _ = get_fs_token_paths(
             path, storage_options=storage_options
         )
@@ -293,7 +297,9 @@ def read_delta_table(
 
 
 def read_delta_history(
-    path: str, limit: Optional[int] = None, storage_options: Dict[str, str] = None,
+    path: str,
+    limit: Optional[int] = None,
+    storage_options: Dict[str, str] = None,
     delta_storage_options: Dict[str, str] = None,
 ) -> dd.core.DataFrame:
     """
@@ -316,7 +322,10 @@ def read_delta_history(
     """
 
     dtw = DeltaTableWrapper(
-        path=path, version=None, columns=None, storage_options=storage_options,
+        path=path,
+        version=None,
+        columns=None,
+        storage_options=storage_options,
         delta_storage_options=delta_storage_options,
     )
     return dtw.history(limit=limit)
@@ -349,7 +358,10 @@ def vacuum(
     """
 
     dtw = DeltaTableWrapper(
-        path=path, version=None, columns=None, storage_options=storage_options,
+        path=path,
+        version=None,
+        columns=None,
+        storage_options=storage_options,
         delta_storage_options=delta_storage_options,
     )
     return dtw.vacuum(retention_hours=retention_hours, dry_run=dry_run)

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -350,6 +350,6 @@ def vacuum(
 
     dtw = DeltaTableWrapper(
         path=path, version=None, columns=None, storage_options=storage_options,
-        delta_storage_options=delta_storage_optoins,
+        delta_storage_options=delta_storage_options,
     )
     return dtw.vacuum(retention_hours=retention_hours, dry_run=dry_run)

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -29,13 +29,14 @@ class DeltaTableWrapper(object):
         columns: List[str],
         datetime: Optional[str] = None,
         storage_options: Dict[str, str] = None,
+        delta_storage_options: Dict[str, str] = None,
     ) -> None:
         self.path: str = path
         self.version: int = version
         self.columns = columns
         self.datetime = datetime
         self.storage_options = storage_options
-        self.dt = DeltaTable(table_uri=self.path, version=self.version)
+        self.dt = DeltaTable(table_uri=self.path, version=self.version, storage_options=delta_storage_options)
         self.fs, self.fs_token, _ = get_fs_token_paths(
             path, storage_options=storage_options
         )
@@ -198,6 +199,7 @@ def read_delta_table(
     columns: List[str] = None,
     storage_options: Dict[str, str] = None,
     datetime: str = None,
+    delta_storage_options: Dict[str, str] = None,
     **kwargs,
 ):
     """
@@ -235,7 +237,9 @@ def read_delta_table(
     columns: None or list(str)
         Columns to load. If None, loads all.
     storage_options : dict, default None
-        Key/value pairs to be passed on to the file-system backend, if any.
+        Key/value pairs to be passed on to the fsspec backend, if any.
+    delta_storage_options : dict, default None
+        Key/value pairs to be passed on to the delta-rs filesystem, if any.
     kwargs: dict,optional
         Some most used parameters can be passed here are:
         1. schema
@@ -282,13 +286,15 @@ def read_delta_table(
             columns=columns,
             storage_options=storage_options,
             datetime=datetime,
+            delta_storage_options=delta_storage_options,
         )
         resultdf = dtw.read_delta_table(columns=columns, **kwargs)
     return resultdf
 
 
 def read_delta_history(
-    path: str, limit: Optional[int] = None, storage_options: Dict[str, str] = None
+    path: str, limit: Optional[int] = None, storage_options: Dict[str, str] = None,
+    delta_storage_options: Dict[str, str] = None,
 ) -> dd.core.DataFrame:
     """
     Run the history command on the DeltaTable.
@@ -310,7 +316,8 @@ def read_delta_history(
     """
 
     dtw = DeltaTableWrapper(
-        path=path, version=None, columns=None, storage_options=storage_options
+        path=path, version=None, columns=None, storage_options=storage_options,
+        delta_storage_options=delta_storage_options,
     )
     return dtw.history(limit=limit)
 
@@ -320,6 +327,7 @@ def vacuum(
     retention_hours: int = 168,
     dry_run: bool = True,
     storage_options: Dict[str, str] = None,
+    delta_storage_options: Dict[str, str] = None,
 ) -> None:
     """
     Run the Vacuum command on the Delta Table: list and delete
@@ -341,6 +349,7 @@ def vacuum(
     """
 
     dtw = DeltaTableWrapper(
-        path=path, version=None, columns=None, storage_options=storage_options
+        path=path, version=None, columns=None, storage_options=storage_options,
+        delta_storage_options=delta_storage_optoins,
     )
     return dtw.vacuum(retention_hours=retention_hours, dry_run=dry_run)


### PR DESCRIPTION
This adds a keyword for users to control the `storage_options` provided to `DeltaTable`.

Without this, users can't read from Azure Blob Storage (easily) without first configuring environment variables:

```
import os
import dask_deltatable
import deltalake

storage_options = {
    "account_name": "tomsynapsetest",
    "sas_token": os.environ["AZURE_SAS_TOKEN"],
}

df = dask_deltatable.read_delta_table(
    "az://test/delta/delta-table-361822/",
    storage_options=storage_options,  # these are provided to fsspec
)
print(df)
```

this raises with

```pytb
python example.py
Traceback (most recent call last):
  File "/home/taugspurger/src/dask/dask_deltatable/example.py", line 10, in <module>
    df = dask_deltatable.read_delta_table(
  File "/home/taugspurger/src/dask/dask_deltatable/dask_deltatable/core.py", line 284, in read_delta_table
    dtw = DeltaTableWrapper(
  File "/home/taugspurger/src/dask/dask_deltatable/dask_deltatable/core.py", line 39, in __init__
    self.dt = DeltaTable(table_uri=self.path, version=self.version, storage_options=delta_storage_options)
  File "/home/taugspurger/src/dask/.direnv/python-3.10.8/lib/python3.10/site-packages/deltalake/table.py", line 122, in __init__
    self._table = RawDeltaTable(
deltalake.PyDeltaTableError: Failed to read delta log object: Generic MicrosoftAzure error: Account must be specified
```

By providing `delta_storage_options`, we can get things working:

```python
python example.py
Dask DataFrame Structure:
                  id
npartitions=5
               int64
                 ...
...              ...
                 ...
                 ...
Dask Name: from-delayed, 6 graph layers
```

Note that I chose to add a new keyword argument rather than passing the fsspec `storage_options` through. I don't think we can assume that they're compatible.